### PR TITLE
Fix invalid date error in Safari

### DIFF
--- a/jews.user.js
+++ b/jews.user.js
@@ -119,7 +119,7 @@ parse['MBN'] = function (jews) {
     })();
     jews.timestamp = {
         created: new Date($('#article_title .reg_dt').text().replace(/-/g, '/')),
-        lastModified: undefined
+        lastModified: new Date($('#article_title .upd_dt').text().replace(/-/g, '/'))
     };
     jews.reporters = [];
 };


### PR DESCRIPTION
Also parse `lastModified` for MBN.
