### PR TITLE
로이터: 파싱 후 #trackbar와 iframe 제거

### DIFF
--- a/jews.user.js
+++ b/jews.user.js
@@ -447,6 +447,9 @@ parse['로이터'] = function (jews) {
         }
         return result;
     })();
+    jews.pesticide = function () {
+        $('#trackbar, iframe').remove();
+    };
 };
 parse['머니투데이'] = function (jews) {
     jews.title = $('#article h1').text();


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3071003/4604751/4a5219d0-51b5-11e4-92b0-5661f97fbcf5.png)

jews로 변환 후 `#trackbar`가 생성되어 이렇게 괴롭히는 현상을 수정했습니다.
살충제 최고
