### PR TITLE
제안: DOMContentLoaded 이벤트 발생 시에 jews 파싱

### DIFF
--- a/jews.user.js
+++ b/jews.user.js
@@ -1641,7 +1641,7 @@ function clearStyles(element) {
 if ('undefined' === typeof window) {
     module.exports = parse;
 } else {
-    window.addEventListener('load', function (e) {
+    var run = function (e) {
         parse(where(window.location.hostname), jews);
         (function () {
             var id = window.setTimeout('0', 0);
@@ -1739,5 +1739,7 @@ if ('undefined' === typeof window) {
         ].join('');
         if (typeof jews.pesticide === 'function')
             window.setInterval(jews.pesticide, jews.spraying_cycle || 1000);
-    }, true);
+    };
+    if (document.readyState === 'interactive' || document.readyState === 'complete') run();
+    else window.addEventListener('DOMContentLoaded', run, true);
 }


### PR DESCRIPTION
Chrome 38(x64, Win 8.1)에서 AdBlock 미사용 시 [세계일보](http://www.segye.com/) 기사 페이지를 접속했을 때 `document.readyState`가 `interactive`에서 머무는 문제가 발견되었습니다. 이에 대한 해결 방안으로 `DOMContentLoaded` 이벤트 발생 시 jews를 파싱하는 것을 제안합니다만, 이미 `load` 이벤트 기준으로 쓰인 코드들과 충돌이 예상되어 세계일보의 경우에만 따로 `DOMContentLoaded` 이벤트 시 발생하도록 처리해야 할까 싶습니다.
