### PR TITLE
KBS 비디오 살리기

### DIFF
--- a/src/impl/KBS.ts
+++ b/src/impl/KBS.ts
@@ -9,12 +9,12 @@ export function parse(): Article {
         title: $('.landing-caption .tit-s').text(),
         content: (() => {
           const ret =
-            $("script").filter((_, scriptTag) => {
-              if(scriptTag.innerHTML.includes("displayVod")) { return scriptTag }
+            $('script').filter((_, scriptTag) => {
+              if(scriptTag.innerHTML.includes('displayVod')) { return scriptTag }
             }).map((_, element) => {
               return element.outerHTML
             }).get().join(' ') +
-            $(".detail-visual")[0].outerHTML + '<br>' +
+            $('.detail-visual')[0].outerHTML + '<br>' +
             clearStyles($('#cont_newstext')[0].cloneNode(true) as HTMLElement).innerHTML
           return ret;
         })(),

--- a/src/impl/KBS.ts
+++ b/src/impl/KBS.ts
@@ -7,7 +7,17 @@ export const readyToParse = () => waitElement('.name span');
 export function parse(): Article {
     return {
         title: $('.landing-caption .tit-s').text(),
-        content: clearStyles($('#cont_newstext')[0].cloneNode(true) as HTMLElement).innerHTML,
+        content: (() => {
+          const ret =
+            $("script").filter((_, scriptTag) => {
+              if(scriptTag.innerHTML.includes("displayVod")) { return scriptTag }
+            }).map((_, element) => {
+              return element.outerHTML
+            }).get().join(' ') +
+            $(".detail-visual")[0].outerHTML + '<br>' +
+            clearStyles($('#cont_newstext')[0].cloneNode(true) as HTMLElement).innerHTML
+          return ret;
+        })(),
         reporters :[{
             name: $('.name span:eq(0)').text(),
             mail: $('.name span:eq(1)').text()

--- a/src/impl/KBS.ts
+++ b/src/impl/KBS.ts
@@ -7,17 +7,12 @@ export const readyToParse = () => waitElement('.name span');
 export function parse(): Article {
     return {
         title: $('.landing-caption .tit-s').text(),
-        content: (() => {
-          const ret =
+        content:
             $('script').filter((_, scriptTag) => {
-              if(scriptTag.innerHTML.includes('displayVod')) { return scriptTag }
-            }).map((_, element) => {
-              return element.outerHTML
-            }).get().join(' ') +
-            $('.detail-visual')[0].outerHTML + '<br>' +
-            clearStyles($('#cont_newstext')[0].cloneNode(true) as HTMLElement).innerHTML
-          return ret;
-        })(),
+                if(scriptTag.innerHTML.includes('displayVod')) { return scriptTag }
+            }).map((_, element) => element.outerHTML).get().join(' ') + //video runtime script
+            $('.detail-visual')[0].outerHTML + '<br>' + //video control elements
+            clearStyles($('#cont_newstext')[0].cloneNode(true) as HTMLElement).innerHTML,
         reporters :[{
             name: $('.name span:eq(0)').text(),
             mail: $('.name span:eq(1)').text()


### PR DESCRIPTION
이슈 : https://github.com/disjukr/just-news/issues/1

굉장히 단순하게 구현하긴 했는데 현재(2019년 2월) 기준으로 detail-visual 을 살려서 스크립트를 끌고오면 동작하는 것 같아 일단 그렇게 구현했습니다

타입스크립트는 잘몰라서

```typescript
return
   obj + obj2 ...
```
으로 구현하려고 했던게 동작하지 않아서

```typescript
const ret =
   obj + obj2 ...
return ret
```
으로 했습니다

풀리퀘는 처음인지라 더 좋은 방법이나 의견 부탁드립니다