### PR TITLE
Fix parsing bugs for nocutnews.co.kr

### DIFF
--- a/src/impl/노컷뉴스.ts
+++ b/src/impl/노컷뉴스.ts
@@ -1,27 +1,34 @@
 import * as $ from 'jquery';
-import { clearStyles } from '../util';
+import {
+    clearStyles,
+    waitElement
+} from '../util';
 import { Article } from 'index';
 
+export const readyToParse = () => waitElement('.view_foot');
+
 export const cleanup = () => {
-    $('#scrollDiv').remove();
+    $('#scrollDiv, body>img').remove();
 }
 
 export function parse(): Article {
     return {
-        title: $('.reporter_info h2').text(),
-        subtitle: $('.viewbox h3').text(),
+        title: $('.h_info h2').text(),
+        subtitle: $('.viewbox h3').html(),
         content: (() => {
             const content = $('#pnlContent')[0].cloneNode(true);
+            $('.viewpic>iframe', content).remove();
+            $('div[style="text-align:right;width:250px;float:right;margin:15px 0px 0px 15px;"]', content).remove();
             $('.relatednews', content).remove();
             return clearStyles(content).innerHTML;
         })(),
         timestamp: {
-            created: new Date($('.reporter_info ul li:first-child span').text().replace(/-/g, '/')),
+            created: new Date($('.h_info ul li:nth-child(2) span').text().replace(/-/g, '/')),
             lastModified: undefined
         },
         reporters: [{
-            name: $('.reporter_info .email span').text(),
-            mail: $('.reporter_info .email a').attr('title')
+            name: $('.h_info .email span').text(),
+            mail: $('.h_info .email a').attr('title')
         }],
     };
 }


### PR DESCRIPTION
Fix #308.

부제목에 `<br>`이 들어가는 경우 두 줄이 붙어 나와 `text()` 대신 `html()`로 변경했습니다.

Link: https://www.nocutnews.co.kr/news/5067376
<img width="683" alt="screenshot 2019-02-18 21 01 14" src="https://user-images.githubusercontent.com/853977/52949693-5ab41700-33c0-11e9-96dd-18a58ee29491.png">
