### PR TITLE
Clean up for kmib.co.kr

### DIFF
--- a/src/impl/국민일보.ts
+++ b/src/impl/국민일보.ts
@@ -6,12 +6,14 @@ import {
 } from '..';
 import {
     clearStyles,
+    waitElement,
 } from '../util';
 
+export const readyToParse = () => waitElement('.best_nw');
 
 // 유투브 동영상(iframe)이 포함된 기사: http://news.kmib.co.kr/article/view.asp?arcid=0012123329&code=61161111&sid1=spo
 // 따라서 단순하게 iframe을 날려버리면 기사 내용이 날라가는 문제가 있을 수 있습니다.
-export const cleanup = () => $('#scrollDiv').remove();
+export const cleanup = () => $('#scrollDiv, body>script, body>iframe, #NeoInteractiveScreenViewLayer, body>div:not([id])').remove();
 
 export function parse(): Article {
     const t = $('.nwsti_btm .date .t11');
@@ -19,8 +21,26 @@ export function parse(): Article {
     return {
         title: $('.nwsti h3').text(),
         content: (() => {
-            const article = $('#article')[0].cloneNode(true) as HTMLElement;
-            $('.best_nw', article).remove();
+            const article = $('#articleBody')[0].cloneNode(true) as HTMLElement;
+            $('a[href^="http://news.kmib.co.kr/article/fbchoice/index.asp"]', article).remove();
+            $('a[href^="http://www.kmib.co.kr/photo/index.asp"]', article).remove();
+            $('a[href^="http://www.kmib.co.kr/vod/index.asp"]', article).remove();
+            const nodes = article.childNodes;
+            const blankRegexp = /^\s*$/;
+            for (var i = nodes.length - 1; i >= 0; i--) {
+                if (nodes[i].nodeType === 3) {
+                    const text = nodes[i].nodeValue as string;
+                    if (blankRegexp.test(text)) {
+                        article.removeChild(nodes[i]);
+                    } else {
+                        break;
+                    }
+                } else if (nodes[i].nodeType === 1 && (nodes[i].nodeName === 'BR' || nodes[i].nodeName === 'FONT')) {
+                    article.removeChild(nodes[i]);
+                } else {
+                    break;
+                }
+            }
             return clearStyles(article).innerHTML;
         })(),
         // 입력, 수정 둘 다 있는 기사: http://news.kmib.co.kr/article/view.asp?arcid=0012123329&code=61161111&sid1=spo


### PR DESCRIPTION
Fix #309.

Tested links:
- http://news.kmib.co.kr/article/view.asp?arcid=0012881052&code=61121111&sid1=soc
- http://news.kmib.co.kr/article/view.asp?arcid=0013075819
- http://news.kmib.co.kr/article/view.asp?arcid=0012123329&code=61161111&sid1=spo
- http://news.kmib.co.kr/article/view.asp?arcid=0013073867&code=61121111

두 번째, 네 번째 링크의 추가 광고의 경우 기사 뒤쪽에 `<font>`로 들어가 있어 뒤쪽부터 빈 노드를 차례로 지우면서 없앴습니다.