### PR TITLE
Fix bug in chosun news

### DIFF
--- a/src/impl/조선일보.ts
+++ b/src/impl/조선일보.ts
@@ -11,7 +11,7 @@ export function parse(): Article {
             return clearStyles(content).innerHTML;
         })(),
         timestamp: (() => {
-            const timeStr = $('#date_text')[0].textContent!;
+            const timeStr = $('.news_date')[0].textContent!;
             let created;
             const cTime = timeStr.match(/입력 : ([^\|]+)/);
             if (cTime !== null) {


### PR DESCRIPTION
Fix https://github.com/disjukr/just-news/issues/317

Selector 가 .newsdate 로 바뀐것 같아 변경하였습니다

Link: http://news.chosun.com/site/data/html_dir/2019/03/06/2019030601355.html