### PR TITLE
fix #321 네이버뉴스 잘못된 작성일

### DIFF
--- a/src/impl/네이버뉴스.ts
+++ b/src/impl/네이버뉴스.ts
@@ -22,10 +22,16 @@ export function parse(): Article {
         })(),
         timestamp: {
             created: (() => {
-                let created = $('.article_info .sponsor .t11').text();
+                let created = $('.article_info .sponsor .t11').eq(0).text();
                 return new Date(created.replace(' ', 'T') + '+09:00'); // ISO 8601
             })(),
-            lastModified: undefined
+            lastModified: (() => {
+                let modified = $('.article_info .sponsor .t11').eq(1).text();
+                if(modified === '') {
+                    return undefined;
+                }
+                return new Date(modified.replace(' ', 'T') + '+09:00'); // ISO 8601
+            })(),
         },
     };
 }


### PR DESCRIPTION
Fix #321 
최종 수정 날짜가 있는 경우 잘못된 작성일으로 표시되는 것을 수정하였습니다.