### PR TITLE
네이버 뉴스 잘못된 작성일 버그 수정

### DIFF
--- a/src/impl/네이버뉴스.ts
+++ b/src/impl/네이버뉴스.ts
@@ -8,6 +8,19 @@ export const cleanup = () => {
 }
 
 export function parse(): Article {
+    const parseTime = (timeInfo: Nullable<string>) => {
+        if (timeInfo) {
+            const iso8601 = timeInfo.replace(/(\d{4}).(\d{2}).(\d{2}). (오전|오후) (\d{1,2}):(\d{2})/, function(_, year, month, day, ampm, hour, minuate) {
+                hour |= 0;
+                if (ampm === "오후") hour += 12;
+                if (hour === 24) hour = 0;
+                hour = hour < 10 ? "0" + hour : hour;
+                return `${year}-${month}-${day}T${hour}:${minuate}+09:00`;
+            })
+            return new Date(iso8601);
+        }
+        return undefined;
+    }
     return {
         title: $('#articleTitle').text(),
         content: (() => {
@@ -23,14 +36,11 @@ export function parse(): Article {
         timestamp: {
             created: (() => {
                 let created = $('.article_info .sponsor .t11').eq(0).text();
-                return new Date(created.replace(' ', 'T') + '+09:00'); // ISO 8601
+                return parseTime(created);
             })(),
             lastModified: (() => {
                 let modified = $('.article_info .sponsor .t11').eq(1).text();
-                if(modified === '') {
-                    return undefined;
-                }
-                return new Date(modified.replace(' ', 'T') + '+09:00'); // ISO 8601
+                return parseTime(modified);
             })(),
         },
     };


### PR DESCRIPTION
이슈 #336 을 수정했습니다.

네이버 뉴스의 작성일 포맷은 오전/오후 가 있고, 시간(hour) 부분이 1자리 또는 2자리 수로 되어있는 것이 특징입니다.

<img width="724" alt="스크린샷 2019-06-06 오후 7 24 54" src="https://user-images.githubusercontent.com/35624130/59026203-ca2b1500-8890-11e9-9729-d809bf8a5dac.png">
https://news.naver.com/main/read.nhn?mode=LSD&sid1=100&mid=shm&oid=001&aid=0010734200&nh=20190402101835
